### PR TITLE
Adjust delays

### DIFF
--- a/khan-cli/Khan/CLI/Launch.hs
+++ b/khan-cli/Khan/CLI/Launch.hs
@@ -119,7 +119,9 @@ launch c@Common{..} l@Launch{..} = capture lAnsible c "launch {}" [show lType] $
         Instance.run l ami lType (AZ cRegion z) 1 1 lOptimised
 
     let ids = concatMap (map riitInstanceId) rs
-
+    -- Sometimes tagging will fail with InvalidInstanceID.NotFound. A two
+    -- second delay seems sufficient to avoid this issue.
+    delaySeconds 2
     Tag.instances l lDomain ids
     Instance.wait ids
     return True

--- a/khan/Khan/Model/IAM/Role.hs
+++ b/khan/Khan/Model/IAM/Role.hs
@@ -91,4 +91,4 @@ update (names -> n@Names{..}) tpath ppath = do
     created (Right _) = return True
     created e         = verifyIAM "EntityAlreadyExists" e >> return False
 
-    delay = 5
+    delay = 8


### PR DESCRIPTION
The new values are based on repeatedly launching a full environment and increasing the values until an entire environment can be launched without a hitch.