### PR TITLE
Add a new default tag

### DIFF
--- a/khan/Khan/Model/Tag.hs
+++ b/khan/Khan/Model/Tag.hs
@@ -158,4 +158,5 @@ defaults (names -> Names{..}) dom =
     , (domain, dom)
     , (name,   appName)
     , (weight, "0")
+    , ("P",    "NP")
     ] ++ maybe [] (\v -> [(version, v)]) versionName


### PR DESCRIPTION
Used as an "epoch" in order to be able to roll out zinfra/hegemony#945 without
requiring to re-deploy everything at once and / or having to silence alerts for
an extended period of time.