### PR TITLE
Drop CBC cipher suites

### DIFF
--- a/khan/src/Khan/Model/ELB/LoadBalancerPolicy.hs
+++ b/khan/src/Khan/Model/ELB/LoadBalancerPolicy.hs
@@ -55,9 +55,7 @@ sslPolicy balancer = CreateLoadBalancerPolicy
 
     ciphers  = [ ("Server-Defined-Cipher-Order", "true")
                , ("ECDHE-RSA-AES256-GCM-SHA384", "true")
-               , ("ECDHE-RSA-AES256-SHA384", "true")
                , ("ECDHE-RSA-AES128-GCM-SHA256", "true")
-               , ("ECDHE-RSA-AES128-SHA256", "true")
                ]
 
 mkPolicyAttribute :: (Text, Text) -> PolicyAttribute


### PR DESCRIPTION
TLS should only use AES GCM or Chacha20Poly1305 cipher suites.

Relates to https://github.com/zinfra/backend-issues/issues/1640