### PR TITLE
Use externally provided version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 SHELL        := /usr/bin/env bash
 NAME         := khan
-VERSION      := $(shell sed -n 's/^version: *\(.*\)$$/\1/p' $(NAME).cabal)
+VERSION      ?=
 BUILD_NUMBER ?= 0
 BUILD        := $(BUILD_NUMBER)$(shell [ "${BUILD_LABEL}" == "" ] && echo "" || echo ".${BUILD_LABEL}")
-DEB          := $(NAME)_$(VERSION)+$(BUILD_NUMBER)_amd64.deb
+DEB          := $(NAME)_$(VERSION)+$(BUILD)_amd64.deb
 DOCKER       ?= false
 
 OUT_CLI      := dist/$(NAME)
@@ -12,7 +12,9 @@ OUT          := $(OUT_CLI) $(OUT_SYNC)
 
 default: all
 
-all: clean install link
+#all: clean install link
+all:
+	echo $(DEB)
 
 init:
 	mkdir -p dist
@@ -52,7 +54,7 @@ $(DEB): $(OUT)
 	makedeb --name=$(NAME) \
 	 --version=$(VERSION) \
 	 --debian-dir=deb \
-	 --build=$(BUILD_NUMBER) \
+	 --build=$(BUILD) \
 	 --architecture=amd64 \
 	 --output-dir=dist
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,12 @@ OUT_CLI      := dist/$(NAME)
 OUT_SYNC     := dist/khan-metadata-sync
 OUT          := $(OUT_CLI) $(OUT_SYNC)
 
+guard-%:
+	@ if [ "${${*}}" = "" ]; then \
+	    echo "Environment variable $* not set"; \
+	    exit 1; \
+	fi
+
 default: all
 
 #all: clean install link
@@ -42,7 +48,7 @@ install: init
 endif
 
 .PHONY: dist
-dist: install $(DEB) .metadata
+dist: guard-VERSION install $(DEB) .metadata
 
 $(OUT_CLI): $(BIN_CLI)
 	strip -o $(OUT_CLI) $<
@@ -50,7 +56,7 @@ $(OUT_CLI): $(BIN_CLI)
 $(OUT_SYNC): $(BIN_SYNC)
 	strip -o $(OUT_SYNC) $<
 
-$(DEB): $(OUT)
+$(DEB): guard-VERSION $(OUT)
 	makedeb --name=$(NAME) \
 	 --version=$(VERSION) \
 	 --debian-dir=deb \


### PR DESCRIPTION
Helps with fixing https://github.com/zinfra/backend-issues/issues/1628 , and partially related to https://github.com/zinfra/backend-issues/issues/963 - this makes it easier to integrate with concourse